### PR TITLE
move the  branch to pensa-repo

### DIFF
--- a/realsense2_camera/include/t265_realsense_node.h
+++ b/realsense2_camera/include/t265_realsense_node.h
@@ -19,10 +19,14 @@ namespace realsense2_camera
         private:
             void initializeOdometryInput();
             void setupSubscribers();
+            void handleWarning();   
             void odom_in_callback(const nav_msgs::Odometry::ConstPtr& msg);
+            void warningDiagnostic (diagnostic_updater::DiagnosticStatusWrapper &stat);
+            diagnostic_updater::Updater callback_updater;
 
             ros::Subscriber _odom_subscriber;
             rs2::wheel_odometer _wo_snr;
             bool _use_odom_in;
+            std::string  _T265_fault;
     };
 }

--- a/realsense2_camera/src/t265_realsense_node.cpp
+++ b/realsense2_camera/src/t265_realsense_node.cpp
@@ -1,5 +1,4 @@
 #include "../include/t265_realsense_node.h"
-#include <functional>
 
 using namespace realsense2_camera;
 
@@ -139,5 +138,4 @@ void T265RealsenseNode::calcAndPublishStaticTransform(const stream_index_pair& s
 void T265RealsenseNode::warningDiagnostic(diagnostic_updater::DiagnosticStatusWrapper& status)
 {
   status.summary(diagnostic_msgs::DiagnosticStatus::WARN, _T265_fault);
-
 }

--- a/realsense2_camera/src/t265_realsense_node.cpp
+++ b/realsense2_camera/src/t265_realsense_node.cpp
@@ -1,4 +1,5 @@
 #include "../include/t265_realsense_node.h"
+#include <functional>
 
 using namespace realsense2_camera;
 
@@ -12,6 +13,7 @@ T265RealsenseNode::T265RealsenseNode(ros::NodeHandle& nodeHandle,
                                      {
                                          _monitor_options = {RS2_OPTION_ASIC_TEMPERATURE, RS2_OPTION_MOTION_MODULE_TEMPERATURE};
                                          initializeOdometryInput();
+                                         handleWarning();
                                      }
 
 void T265RealsenseNode::initializeOdometryInput()
@@ -45,6 +47,22 @@ void T265RealsenseNode::publishTopics()
 {
     BaseRealSenseNode::publishTopics();
     setupSubscribers();
+}
+
+void  T265RealsenseNode::handleWarning()
+{
+    rs2::log_to_callback( rs2_log_severity::RS2_LOG_SEVERITY_WARN, [&]
+      ( rs2_log_severity severity, rs2::log_message const & msg ) noexcept {
+        _T265_fault =  msg.raw();
+        std::array<std::string, 2> list_of_fault{"SLAM_ERROR", "Stream transfer failed, exiting"};
+        auto it = std::find_if(begin(list_of_fault), end(list_of_fault),
+                  [&](const std::string& s) {return _T265_fault.find(s) != std::string::npos; });
+        if (it != end(list_of_fault))
+        {
+          callback_updater.add("Warning ",this, & T265RealsenseNode::warningDiagnostic);
+          callback_updater.force_update();
+        }
+    });
 }
 
 void T265RealsenseNode::setupSubscribers()
@@ -116,4 +134,10 @@ void T265RealsenseNode::calcAndPublishStaticTransform(const stream_index_pair& s
             publish_static_tf(transform_ts_, zero_trans, quaternion_optical, _depth_aligned_frame_id[stream], _optical_frame_id[stream]);
         }
     }
+}
+
+void T265RealsenseNode::warningDiagnostic(diagnostic_updater::DiagnosticStatusWrapper& status)
+{
+  status.summary(diagnostic_msgs::DiagnosticStatus::WARN, _T265_fault);
+
 }


### PR DESCRIPTION
**Related PR**

see https://github.com/Pensasystems/pensa-ros/pull/965

**Describe the solution**
`t265realsense_camera` will Publish `slam_error` and `Stream transfer failed, exiting` to ` /diagnostics` topic. so in pensa_ros we have this ability to subscribe to this topic and capture the T265 errors. 
